### PR TITLE
Bugfix-85 : Fix switch to state 2 when unregister from outing

### DIFF
--- a/src/Controller/OutingController.php
+++ b/src/Controller/OutingController.php
@@ -240,14 +240,17 @@ class OutingController extends AbstractController
      */
     public function removeParticipant(Outing $outing): Response
     {
-        if ($outing->getStartDate() > new \DateTime('now'))
-        {
+        if ($outing->getStartDate() > new \DateTime('now')) {
             $outing->removeParticipant($this->getUser());
+            if ($outing->getRegistrationDeadLine() > new DateTime() && count($outing->getParticipants()) < $outing->getMaxParticipants()) {
+                $stateRepo = $this->getDoctrine()->getRepository(State::class);
+                $outing->setState($stateRepo->find(2));
+            }
             $this->getDoctrine()->getManager()->flush();
-            $this->addFlash('success', 'Votre annulation à la sortie à bien été prise en compte');
+            $this->addFlash('success', 'Votre désinscription de la sortie a bien été enregistrée.');
             return $this->redirectToRoute('app_home');
-        }else
-        {
+        } else {
+            $this->addFlash('warning', "Vous ne pouvez plus vous désinscrire de cette sortie, elle a déjà commencé.");
             return $this->redirectToRoute('app_home');
         }
         


### PR DESCRIPTION
Switch to state 2 if registration deadline and max number of participants are not met.
Edit flash message if unregistration successful.
Add flash message if unregistration is not possible.